### PR TITLE
修改长度计算方式

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -110,8 +110,7 @@ class AppServiceProvider extends ServiceProvider
 
         list($min, $max) = $parameters;
 
-        preg_match_all('/[a-zA-Z0-9_]/', $value, $single);
-        $length = count($single[0]) / 2 + mb_strlen(preg_replace('([a-zA-Z0-9_])', '', $value));
+        $length = strlen(mb_convert_encoding($value, 'GB18030', 'UTF-8')) / 2;
 
         return $length >= $min && $length <= $max;
     }


### PR DESCRIPTION
将字符串转换为 GB18030 编码，然后再计算字节：

英文字母符号数字 计算结果为0.5；汉字计算结果为1；emoji计算结果为2。

计算结果和微信的用户名规则一致： 英文字符36个，汉字16个，emoji支持8个。